### PR TITLE
Fix unimported urllib due to bad indentation

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -26,10 +26,10 @@ try:
 except ImportError:
     from itertools import zip_longest as izip_longest
 
-    try:
-        from urllib import urlretrieve as urlretrieve
-    except ImportError:
-        from urllib.request import urlretrieve as urlretrieve
+try:
+    from urllib import urlretrieve as urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve as urlretrieve
 
 try:
     quote_plus = urllib.quote_plus


### PR DESCRIPTION
I just saw `urlretrieve` wasn't imported while trying to installing a ZIP from an online URL.

Error log:
```
2020-04-24 04:59:50.716 T:7555  NOTICE: Indigo NOTICE: Installer: Installing: plugin.video.kodipopcorntime-1.7.4b.zip
2020-04-24 04:59:54.897 T:31519  NOTICE: Trying to open: samplerate: 44100, channelMask: 12, encoding: 4
2020-04-24 04:59:54.948 T:31519  NOTICE: CAESinkAUDIOTRACK::Initializing with: m_sampleRate: 44100 format: AE_FMT_FLOAT (AE) method: PCM stream-type: PCM-STREAM min_buffer_size: 60208 m_frames: 3763 m_frameSize: 8 channels: 2
2020-04-24 04:59:55.629 T:7555  NOTICE: Indigo NOTICE:  DOWNLOADING FILE:plugin.video.kodipopcorntime-1.7.4b.zip.zip
2020-04-24 04:59:55.630 T:7555  NOTICE: Indigo NOTICE: From: https://gihub.com/markop159/markop159-repository/blob/master/releases/plugin.kodipopcorntime.beta/plugin.video.kodipopcorntime-1.7.4b.zip
2020-04-24 04:59:56.059 T:7555   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.NameError'>
                                            Error Contents: global name 'urlretrieve' is not defined
                                            Traceback (most recent call last):
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.program.indigo/default.py", line 677, in <module>
                                                installer.install_from_url()
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.program.indigo/installer.py", line 956, in install_from_url
                                                addon_install(name, zip_url, '')
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.program.indigo/installer.py", line 884, in addon_install
                                                download(url, lib, addonfolder, name)
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.program.indigo/installer.py", line 967, in download
                                                urlretrieve(url, dest, lambda nb, bs, fs: _pbhook(nb, bs, fs, dp))
                                            NameError: global name 'urlretrieve' is not defined
                                            -->End of Python script error report<--
```